### PR TITLE
Set footer year automatically

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,10 @@
 'use strict';
 
 document.addEventListener('DOMContentLoaded', () => {
+    const copyrElem = document.getElementById('copyr');
+    if (copyrElem) {
+        copyrElem.textContent = new Date().getFullYear();
+    }
     const container = document.querySelector('#cont');
     const themeSwitch = document.getElementById('themeSwitch');
 


### PR DESCRIPTION
## Summary
- update JS to set the footer copyright year using `new Date().getFullYear()`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883c72cd67083219b5cc8af2fdf2e0d